### PR TITLE
Add support for SVG animations

### DIFF
--- a/.changeset/tidy-parents-explain.md
+++ b/.changeset/tidy-parents-explain.md
@@ -1,0 +1,11 @@
+---
+'@vtbag/element-crossing': patch
+---
+
+Extend `anim` expression with support for SVG animations.
+
+To transfer the SVG animation state to the new document use the `/svg` key for the `anim` expression
+
+```html
+<svg data-vtbag-x="id:svg anim:/svg">...</svg>
+```

--- a/src/vanilla.ts
+++ b/src/vanilla.ts
@@ -263,7 +263,9 @@ function restore(values: ElementSpec[]) {
 							);
 							break;
 						}
-						element.setCurrentTime(parseFloat(s.value ?? '0'));
+						element.setCurrentTime(
+							parseFloat(s.value ?? '0') + (new Date().getTime() - elementSpec.timestamp) / 1000
+						);
 					case 'elem':
 						const crossing = top?.__vtbag?.elementCrossing;
 						if (crossing?.fun) {

--- a/src/vanilla.ts
+++ b/src/vanilla.ts
@@ -167,6 +167,20 @@ function elementSpec(element: HTMLElement) {
 						specs.push({ kind, key, value: '' + (animations[0].currentTime ?? 0) });
 					}
 					break;
+				case 'svg-anim':
+					if (!(element instanceof SVGSVGElement)) {
+						console.error(
+							'[crossing]',
+							`retrieval: element for ${key} is not an SVG element`,
+							element
+						);
+						break;
+					}
+					const currentTime = element.getCurrentTime();
+					if (currentTime > 0) {
+						specs.push({ kind, key, value: currentTime.toString() });
+					}
+					break;
 				case 'elem':
 					const crossing = top?.__vtbag?.elementCrossing;
 					if (crossing?.fun) {
@@ -240,6 +254,16 @@ function restore(values: ElementSpec[]) {
 									~~(s.value ?? '0') + (new Date().getTime() - elementSpec.timestamp))
 						);
 						break;
+					case 'svg-anim':
+						if (!(element instanceof SVGSVGElement)) {
+							console.error(
+								'[crossing]',
+								`restore: element for ${s.key} is not an SVG element`,
+								element
+							);
+							break;
+						}
+						element.setCurrentTime(parseFloat(s.value ?? '0'));
 					case 'elem':
 						const crossing = top?.__vtbag?.elementCrossing;
 						if (crossing?.fun) {


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to the vtbag packages!  -->
### Description

Adds support for transferring SVG animation state, which is achieved by getting the animation time via `SVGSVGElement.getCurrentTime()` and setting the time via `SVGSVGElement.setCurrentTime()`.

Todo:

- [x] decide whether to keep the preliminary `svg-anim` name
- [x] add abbreviated name

### Tests

Added an animated SVG element to the vt-bag website and tested that the animation state is transferred
[Recording](https://github.com/user-attachments/assets/49c81f6b-c656-4ad5-bc7a-a6c50ddd1b32)


### Docs & Examples

https://github.com/vtbag/website/pull/39
